### PR TITLE
Match estraverse devDep to peerDep, fix #5

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
   "devDependencies": {
     "chai": "^1.9.1",
     "esprima-fb": "^8001.1001.0-dev-harmony-fb",
-    "estraverse": "^1.7.0",
+    "estraverse": "*",
     "mocha": "^1.20.0"
   }
 }


### PR DESCRIPTION
I think this may be causing issues for a lot of people by creating the conditions for NPM v3’s deduplication to sometimes choose a 1.7.x version of estraverse to install and use. See, for example, https://github.com/npm/npm/issues/9708#issuecomment-144667135