### PR TITLE
Change "Text: null," to "Text: [],"

### DIFF
--- a/keys.js
+++ b/keys.js
@@ -8,7 +8,7 @@ var unprefixedKeys = {
 	ClosingElement: ['name'],
 	OpeningElement: ['name', 'attributes'],
 	Attribute: ['name', 'value'],
-	Text: null,
+	Text: [],
 	SpreadAttribute: ['argument']
 };
 


### PR DESCRIPTION
Having the property "Text" set to null causes error with the JSXText Node.

For example when using it with "esquery":
```
Uncaught Error: Unknown node type JSXText.
traverse	@	...node_modules/estraverse/estraverse.js:517
traverse	@	...node_modules/estraverse/estraverse.js:709
match	@	...node_modules/esquery/esquery/esquery.js:268
(anonymous)	@	main.js [sm]:18
```