### PR TITLE
Update estraverse

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,2 +1,2 @@
 language: node_js
-node_js: '0.10'
+node_js: '6.10.0'

--- a/package.json
+++ b/package.json
@@ -22,6 +22,6 @@
     "chai": "^1.9.1",
     "esprima-fb": "^8001.1001.0-dev-harmony-fb",
     "estraverse": "^1.7.0",
-    "mocha": "^1.20.0"
+    "mocha": "^4.0.1"
   }
 }


### PR DESCRIPTION
I'm updating the estraverse dependency to deprecate jade, use the latest of graceful-fs and minimatch.
I think it won't break anything.